### PR TITLE
資料ダウンロード＋参加申込フォームURL差し替え

### DIFF
--- a/public/entry.html
+++ b/public/entry.html
@@ -132,7 +132,7 @@
             </h2>
         </div>
         <div class="entry-button-wrapper">
-            <a href="https://docs.google.com/forms/d/e/1FAIpQLSdD65-WeqGxwLX_sQPdZ5lX1GWDX8Aio9aJnIBsu3bd5lS07g/viewform" target="_blank" style="text-decoration: none;">
+            <a href="https://docs.google.com/forms/d/e/1FAIpQLSddJmALD7MLVv8F6QXC4xH2NqlT7MGaFB1TYGYISkfljRiKbA/viewform?usp=header" target="_blank" style="text-decoration: none;">
                 <div class="entry-button">
                     <p>申し込みフォーム</p>
                     <img src="img/conversion-arrow.png" alt="conversion-arrow">
@@ -144,7 +144,7 @@
         <div class="footer-content site-box">
             <div class="footer-left-block">
                 <div class="conversion-block footer-conversion">
-                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSchgmln-ltu06o0leiMRyT-MHVKzk6jsGwT1W_l7vq4SFxpGg/viewform" target="_blank">
+                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSdDGraZtbpalSXeKzYzRYUGEkVQP-l6aLMeF1FaB9cifhGbCw/viewform?usp=header" target="_blank">
                         <div class="conversion conversion-document">
                             <img src="img/conversion-document.png" alt="conversion-icon" class="conversion-document-icon">
                             <p>資料のダウンロードはこちら</p>

--- a/public/events.html
+++ b/public/events.html
@@ -60,7 +60,7 @@
         <div class="footer-content site-box">
             <div class="footer-left-block">
                 <div class="conversion-block footer-conversion">
-                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSchgmln-ltu06o0leiMRyT-MHVKzk6jsGwT1W_l7vq4SFxpGg/viewform" target="_blank">
+                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSdDGraZtbpalSXeKzYzRYUGEkVQP-l6aLMeF1FaB9cifhGbCw/viewform?usp=header" target="_blank">
                         <div class="conversion conversion-document">
                             <img src="img/conversion-document.png" alt="conversion-icon" class="conversion-document-icon">
                             <p>資料のダウンロードはこちら</p>

--- a/public/index.html
+++ b/public/index.html
@@ -140,7 +140,7 @@
                 <img src="img/our-consortium-image.png" alt="our consortium image">
             </div>
             <div class="conversion-block">
-                <a href="https://docs.google.com/forms/d/e/1FAIpQLSchgmln-ltu06o0leiMRyT-MHVKzk6jsGwT1W_l7vq4SFxpGg/viewform" target="_blank">
+                <a href="https://docs.google.com/forms/d/e/1FAIpQLSdDGraZtbpalSXeKzYzRYUGEkVQP-l6aLMeF1FaB9cifhGbCw/viewform?usp=header" target="_blank">
                     <div class="conversion conversion-document">
                         <img src="img/conversion-document.png" alt="conversion-icon" class="conversion-document-icon">
                         <p>資料のダウンロードはこちら</p>
@@ -322,7 +322,7 @@
         <div class="footer-content site-box">
             <div class="footer-left-block">
                 <div class="conversion-block footer-conversion">
-                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSchgmln-ltu06o0leiMRyT-MHVKzk6jsGwT1W_l7vq4SFxpGg/viewform" target="_blank">
+                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSdDGraZtbpalSXeKzYzRYUGEkVQP-l6aLMeF1FaB9cifhGbCw/viewform?usp=header" target="_blank">
                         <div class="conversion conversion-document">
                             <img src="img/conversion-document.png" alt="conversion-icon" class="conversion-document-icon">
                             <p>資料のダウンロードはこちら</p>

--- a/public/index.html
+++ b/public/index.html
@@ -239,9 +239,6 @@
                     </ul>
                 </div>
                 <div class="one-member">
-                    <h5>活水女子大学</h5>
-                </div>
-                <div class="one-member">
                     <h5>大妻女子大学 キャリア教育センター</h5>
                     <ul><li>井上 俊也 教授</li></ul>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,6 @@
                 <ul class="slideshow">
                     <li><img src="img/logos/adobe.png" alt="adobe"></li>
                     <li><img src="img/logos/asial.png" alt="asial"></li>
-                    <li><img src="img/logos/kassui-joshi.jpg" alt="活水女子大学"></li>
                     <li><img src="img/logos/nihon-joshi.png" alt="日本女子大学"></li>
                     <li><img src="img/logos/tokyo-joshi.png" alt="東京女子大学"></li>
                     <li><img src="img/logos/tuda-juku.png" alt="津田塾大学"></li>
@@ -66,7 +65,6 @@
                 <ul class="slideshow">
                     <li><img src="img/logos/adobe.png" alt="adobe"></li>
                     <li><img src="img/logos/asial.png" alt="asial"></li>
-                    <li><img src="img/logos/kassui-joshi.jpg" alt="活水女子大学"></li>
                     <li><img src="img/logos/nihon-joshi.png" alt="日本女子大学"></li>
                     <li><img src="img/logos/tokyo-joshi.png" alt="東京女子大学"></li>
                     <li><img src="img/logos/tuda-juku.png" alt="津田塾大学"></li>


### PR DESCRIPTION
## 以下の内容を更新しました

### 資料ダウンロードボタンURL➡︎[Googleフォーム](https://docs.google.com/forms/d/e/1FAIpQLSdDGraZtbpalSXeKzYzRYUGEkVQP-l6aLMeF1FaB9cifhGbCw/viewform?usp=header)に置き換え
  - 変更ページ
    - index.html
    - index.html > footer
    - events.html > footer
    - entry.html > footer


### 参加フォームボタンURL➡︎[Googleフォーム](https://docs.google.com/forms/d/e/1FAIpQLSddJmALD7MLVv8F6QXC4xH2NqlT7MGaFB1TYGYISkfljRiKbA/viewform?usp=header)に置き換え
  - 変更ページ
    - entry.html
    
 お手隙の際にレビューをよろしくお願いいたします。